### PR TITLE
예약 도메인을 생성한다 

### DIFF
--- a/src/main/java/poomasi/domain/farm/_schedule/entity/FarmSchedule.java
+++ b/src/main/java/poomasi/domain/farm/_schedule/entity/FarmSchedule.java
@@ -1,10 +1,7 @@
 package poomasi.domain.farm._schedule.entity;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.Comment;
 
 import java.time.LocalDate;
@@ -24,6 +21,7 @@ public class FarmSchedule {
     @Comment("예약 가능 날짜")
     private LocalDate date;
 
+    @Setter
     @Comment("예약 가능 여부")
     @Enumerated(EnumType.STRING)
     private ScheduleStatus status;
@@ -38,4 +36,5 @@ public class FarmSchedule {
     public void updateStatus(ScheduleStatus status) {
         this.status = status;
     }
+
 }

--- a/src/main/java/poomasi/domain/farm/_schedule/service/FarmScheduleService.java
+++ b/src/main/java/poomasi/domain/farm/_schedule/service/FarmScheduleService.java
@@ -68,4 +68,12 @@ public class FarmScheduleService {
 
         return farmSchedule;
     }
+
+    public void updateFarmScheduleStatus(Long farmScheduleId, ScheduleStatus status) {
+        FarmSchedule farmSchedule = farmScheduleRepository.findById(farmScheduleId)
+                .orElseThrow(() -> new BusinessException(FARM_SCHEDULE_NOT_FOUND));
+
+        farmSchedule.setStatus(status);
+        farmScheduleRepository.save(farmSchedule);
+    }
 }

--- a/src/main/java/poomasi/domain/farm/_schedule/service/FarmScheduleService.java
+++ b/src/main/java/poomasi/domain/farm/_schedule/service/FarmScheduleService.java
@@ -6,6 +6,7 @@ import poomasi.domain.farm._schedule.dto.FarmScheduleRequest;
 import poomasi.domain.farm._schedule.dto.FarmScheduleResponse;
 import poomasi.domain.farm._schedule.dto.FarmScheduleUpdateRequest;
 import poomasi.domain.farm._schedule.entity.FarmSchedule;
+import poomasi.domain.farm._schedule.entity.ScheduleStatus;
 import poomasi.domain.farm._schedule.repository.FarmScheduleRepository;
 import poomasi.global.error.BusinessException;
 
@@ -14,8 +15,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static poomasi.global.error.BusinessError.FARM_SCHEDULE_ALREADY_EXISTS;
-import static poomasi.global.error.BusinessError.START_DATE_SHOULD_BE_BEFORE_END_DATE;
+import static poomasi.global.error.BusinessError.*;
 
 @Service
 @RequiredArgsConstructor
@@ -54,5 +54,18 @@ public class FarmScheduleService {
                 .toList();
     }
 
+    public FarmSchedule getFarmScheduleByFarmIdAndDate(Long farmId, LocalDate date) {
+        return farmScheduleRepository.findByFarmIdAndDate(farmId, date)
+                .orElseThrow(() -> new BusinessException(FARM_SCHEDULE_NOT_FOUND));
+    }
 
+    public FarmSchedule getValidFarmScheduleByFarmIdAndDate(Long farmId, LocalDate date) {
+        FarmSchedule farmSchedule = getFarmScheduleByFarmIdAndDate(farmId, date);
+
+        if (farmSchedule.getStatus() == ScheduleStatus.RESERVED) {
+            throw new BusinessException(FARM_SCHEDULE_ALREADY_RESERVED);
+        }
+
+        return farmSchedule;
+    }
 }

--- a/src/main/java/poomasi/domain/farm/controller/FarmController.java
+++ b/src/main/java/poomasi/domain/farm/controller/FarmController.java
@@ -7,22 +7,22 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import poomasi.domain.farm.service.FarmService;
+import poomasi.domain.farm.service.FarmPlatformService;
 
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/farm")
 public class FarmController {
-    private final FarmService farmService;
+    private final FarmPlatformService farmPlatformService;
 
     @GetMapping("/{farmId}")
     public ResponseEntity<?> getFarm(@PathVariable Long farmId) {
-        return ResponseEntity.ok(farmService.getFarmByFarmId(farmId));
+        return ResponseEntity.ok(farmPlatformService.getFarmByFarmId(farmId));
     }
 
     @GetMapping("")
     public ResponseEntity<?> getFarmList(Pageable pageable) {
-        return ResponseEntity.ok(farmService.getFarmList(pageable));
+        return ResponseEntity.ok(farmPlatformService.getFarmList(pageable));
     }
 }

--- a/src/main/java/poomasi/domain/farm/service/FarmPlatformService.java
+++ b/src/main/java/poomasi/domain/farm/service/FarmPlatformService.java
@@ -1,0 +1,25 @@
+package poomasi.domain.farm.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import poomasi.domain.farm.dto.FarmResponse;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class FarmPlatformService {
+    private final FarmService farmService;
+
+    public FarmResponse getFarmByFarmId(Long farmId) {
+        return FarmResponse.fromEntity(farmService.getFarmByFarmId(farmId));
+    }
+
+    public List<FarmResponse> getFarmList(Pageable pageable) {
+        return farmService.getFarmList(pageable).stream()
+                .map(FarmResponse::fromEntity)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/poomasi/domain/farm/service/FarmService.java
+++ b/src/main/java/poomasi/domain/farm/service/FarmService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import poomasi.domain.farm.dto.FarmResponse;
+import poomasi.domain.farm.entity.Farm;
 import poomasi.domain.farm.repository.FarmRepository;
 import poomasi.global.error.BusinessError;
 import poomasi.global.error.BusinessException;
@@ -16,16 +17,13 @@ import java.util.stream.Collectors;
 public class FarmService {
     private final FarmRepository farmRepository;
 
-    public FarmResponse getFarmByFarmId(Long farmId) {
+    public Farm getFarmByFarmId(Long farmId) {
         return farmRepository.findByIdAndDeletedAtIsNull(farmId)
-                .map(FarmResponse::fromEntity)
                 .orElseThrow(() -> new BusinessException(BusinessError.FARM_NOT_FOUND));
     }
 
-
-    public List<FarmResponse> getFarmList(Pageable pageable) {
+    public List<Farm> getFarmList(Pageable pageable) {
         return farmRepository.findByDeletedAtIsNull(pageable).stream()
-                .map(FarmResponse::fromEntity)
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/poomasi/domain/farm/service/FarmService.java
+++ b/src/main/java/poomasi/domain/farm/service/FarmService.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import poomasi.domain.farm.dto.FarmResponse;
 import poomasi.domain.farm.entity.Farm;
+import poomasi.domain.farm.entity.FarmStatus;
 import poomasi.domain.farm.repository.FarmRepository;
 import poomasi.global.error.BusinessError;
 import poomasi.global.error.BusinessException;
@@ -16,6 +17,14 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class FarmService {
     private final FarmRepository farmRepository;
+
+    public Farm getValidFarmByFarmId(Long farmId) {
+        Farm farm = getFarmByFarmId(farmId);
+        if (farm.getStatus() != FarmStatus.OPEN) {
+            throw new BusinessException(BusinessError.FARM_NOT_OPEN);
+        }
+        return farm;
+    }
 
     public Farm getFarmByFarmId(Long farmId) {
         return farmRepository.findByIdAndDeletedAtIsNull(farmId)

--- a/src/main/java/poomasi/domain/member/entity/Member.java
+++ b/src/main/java/poomasi/domain/member/entity/Member.java
@@ -52,7 +52,7 @@ public class Member {
         this.role = role;
     }
 
-    public Member(String email, Role role){
+    public Member(String email, Role role) {
         this.email = email;
         this.role = role;
     }
@@ -72,5 +72,9 @@ public class Member {
 
     public boolean isFarmer() {
         return role == Role.ROLE_FARMER;
+    }
+
+    public boolean isAdmin() {
+        return role == Role.ROLE_ADMIN;
     }
 }

--- a/src/main/java/poomasi/domain/member/service/MemberService.java
+++ b/src/main/java/poomasi/domain/member/service/MemberService.java
@@ -39,4 +39,9 @@ public class MemberService {
         return memberRepository.findByIdAndDeletedAtIsNull(memberId)
                 .orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND));
     }
+
+    public boolean isAdmin(Long memberId) {
+        Member member = findMemberById(memberId);
+        return member.isAdmin();
+    }
 }

--- a/src/main/java/poomasi/domain/reservation/controller/ReservationFarmerController.java
+++ b/src/main/java/poomasi/domain/reservation/controller/ReservationFarmerController.java
@@ -1,0 +1,22 @@
+package poomasi.domain.reservation.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import poomasi.domain.reservation.service.ReservationFarmerService;
+
+@RequestMapping("/api/v1/farmer/reservations")
+@RestController
+@RequiredArgsConstructor
+public class ReservationFarmerController {
+    private final ReservationFarmerService reservationFarmerService;
+
+    @GetMapping("")
+    public ResponseEntity<?> getReservations() {
+        // FIXME : 임시로 farmerId를 1로 고정
+        Long farmerId = 1L;
+        return ResponseEntity.ok(reservationFarmerService.getReservationsByFarmerId(farmerId));
+    }
+}

--- a/src/main/java/poomasi/domain/reservation/controller/ReservationPlatformController.java
+++ b/src/main/java/poomasi/domain/reservation/controller/ReservationPlatformController.java
@@ -2,10 +2,7 @@ package poomasi.domain.reservation.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import poomasi.domain.reservation.dto.request.ReservationRequest;
 import poomasi.domain.reservation.dto.response.ReservationResponse;
 import poomasi.domain.reservation.service.ReservationPlatformService;
@@ -22,5 +19,12 @@ public class ReservationPlatformController {
         return ResponseEntity.ok(reservation);
     }
 
+    @GetMapping("/get/{reservationId}")
+    public ResponseEntity<?> getReservation(@PathVariable Long reservationId) {
+        // FIXME: 로그인한 사용자의 ID를 가져오도록 수정
+        Long memberId = 1L;
+        ReservationResponse reservation = reservationPlatformService.getReservation(memberId, reservationId);
+        return ResponseEntity.ok(reservation);
+    }
 
 }

--- a/src/main/java/poomasi/domain/reservation/controller/ReservationPlatformController.java
+++ b/src/main/java/poomasi/domain/reservation/controller/ReservationPlatformController.java
@@ -27,4 +27,13 @@ public class ReservationPlatformController {
         return ResponseEntity.ok(reservation);
     }
 
+    @PostMapping("/cancel/{reservationId}")
+    public ResponseEntity<?> cancelReservation(@PathVariable Long reservationId) {
+        // FIXME: 로그인한 사용자의 ID를 가져오도록 수정
+        Long memberId = 1L;
+
+        reservationPlatformService.cancelReservation(memberId, reservationId);
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/src/main/java/poomasi/domain/reservation/controller/ReservationPlatformController.java
+++ b/src/main/java/poomasi/domain/reservation/controller/ReservationPlatformController.java
@@ -1,0 +1,26 @@
+package poomasi.domain.reservation.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import poomasi.domain.reservation.dto.request.ReservationRequest;
+import poomasi.domain.reservation.dto.response.ReservationResponse;
+import poomasi.domain.reservation.service.ReservationPlatformService;
+
+@RestController
+@RequestMapping("/api/reservation")
+@RequiredArgsConstructor
+public class ReservationPlatformController {
+    private final ReservationPlatformService reservationPlatformService;
+
+    @PostMapping("/create")
+    public ResponseEntity<?> createReservation(@RequestBody ReservationRequest request) {
+        ReservationResponse reservation = reservationPlatformService.createReservation(request);
+        return ResponseEntity.ok(reservation);
+    }
+
+
+}

--- a/src/main/java/poomasi/domain/reservation/dto/request/ReservationRequest.java
+++ b/src/main/java/poomasi/domain/reservation/dto/request/ReservationRequest.java
@@ -1,0 +1,30 @@
+package poomasi.domain.reservation.dto.request;
+
+import lombok.Builder;
+import poomasi.domain.farm._schedule.entity.FarmSchedule;
+import poomasi.domain.farm.entity.Farm;
+import poomasi.domain.member.entity.Member;
+import poomasi.domain.reservation.entity.Reservation;
+
+import java.time.LocalDate;
+
+@Builder
+public record ReservationRequest(
+        Long farmId,
+        Long memberId,
+        LocalDate reservationDate,
+
+        int reservationCount,
+        String request
+) {
+    public Reservation toEntity(Member member, Farm farm, FarmSchedule farmSchedule) {
+        return Reservation.builder()
+                .member(member)
+                .farm(farm)
+                .scheduleId(farmSchedule)
+                .reservationDate(reservationDate)
+                .reservationCount(reservationCount)
+                .request(request)
+                .build();
+    }
+}

--- a/src/main/java/poomasi/domain/reservation/dto/response/ReservationResponse.java
+++ b/src/main/java/poomasi/domain/reservation/dto/response/ReservationResponse.java
@@ -1,0 +1,19 @@
+package poomasi.domain.reservation.dto.response;
+
+import lombok.Builder;
+import poomasi.domain.reservation.entity.ReservationStatus;
+
+import java.time.LocalDate;
+
+@Builder
+public record ReservationResponse(
+        Long farmId,
+        Long memberId,
+        Long scheduleId,
+        LocalDate reservationDate,
+        int reservationCount,
+        ReservationStatus status,
+        String request
+
+) {
+}

--- a/src/main/java/poomasi/domain/reservation/dto/response/ReservationResponse.java
+++ b/src/main/java/poomasi/domain/reservation/dto/response/ReservationResponse.java
@@ -11,7 +11,7 @@ public record ReservationResponse(
         Long memberId,
         Long scheduleId,
         LocalDate reservationDate,
-        int reservationCount,
+        int memberCount,
         ReservationStatus status,
         String request
 

--- a/src/main/java/poomasi/domain/reservation/entity/Reservation.java
+++ b/src/main/java/poomasi/domain/reservation/entity/Reservation.java
@@ -9,6 +9,7 @@ import org.hibernate.annotations.Comment;
 import poomasi.domain.farm._schedule.entity.FarmSchedule;
 import poomasi.domain.farm.entity.Farm;
 import poomasi.domain.member.entity.Member;
+import poomasi.domain.reservation.dto.response.ReservationResponse;
 
 import java.time.LocalDate;
 
@@ -65,5 +66,17 @@ public class Reservation {
         this.reservationCount = reservationCount;
         this.status = status;
         this.request = request;
+    }
+
+    public ReservationResponse toResponse() {
+        return ReservationResponse.builder()
+                .farmId(farm.getId())
+                .memberId(member.getId())
+                .scheduleId(scheduleId.getId())
+                .reservationDate(reservationDate)
+                .reservationCount(reservationCount)
+                .status(status)
+                .request(request)
+                .build();
     }
 }

--- a/src/main/java/poomasi/domain/reservation/entity/Reservation.java
+++ b/src/main/java/poomasi/domain/reservation/entity/Reservation.java
@@ -6,12 +6,15 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 import poomasi.domain.farm._schedule.entity.FarmSchedule;
 import poomasi.domain.farm.entity.Farm;
 import poomasi.domain.member.entity.Member;
 import poomasi.domain.reservation.dto.response.ReservationResponse;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -28,33 +31,46 @@ public class Reservation {
     @Comment("농장")
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "farm_id")
+    @Column(nullable = false)
     private Farm farm;
 
     @Comment("예약자")
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
+    @Column(nullable = false)
     private Member member;
 
     @Comment("예약 시간")
-    @Column(name = "reservation_time")
     @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "schedule_id")
+    @Column(nullable = false)
     private FarmSchedule scheduleId;
 
     @Comment("예약 날짜")
-    @Column(name = "reservation_date")
+    @Column(nullable = false)
     private LocalDate reservationDate;
 
     @Comment("예약 인원")
-    @Column(name = "reservation_count")
+    @Column(nullable = false)
     private int reservationCount;
 
     @Comment("예약 상태")
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private ReservationStatus status;
 
     @Comment("요청 사항")
-    @Column(name = "request")
+    @Column(nullable = false)
     private String request;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+    @Comment("예약 취소 일자")
+    private LocalDateTime canceledAt;
 
 
     @Builder
@@ -78,5 +94,14 @@ public class Reservation {
                 .status(status)
                 .request(request)
                 .build();
+    }
+
+    public boolean isCanceled() {
+        return status == ReservationStatus.CANCELED;
+    }
+
+    public void cancel() {
+        this.status = ReservationStatus.CANCELED;
+        this.canceledAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/poomasi/domain/reservation/entity/Reservation.java
+++ b/src/main/java/poomasi/domain/reservation/entity/Reservation.java
@@ -1,0 +1,69 @@
+package poomasi.domain.reservation.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+import poomasi.domain.farm._schedule.entity.FarmSchedule;
+import poomasi.domain.farm.entity.Farm;
+import poomasi.domain.member.entity.Member;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Table(name = "reservation", indexes = {
+        @Index(name = "idx_farm_id", columnList = "farm_id"),
+        @Index(name = "idx_user_id", columnList = "user_id")
+})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Reservation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Comment("농장")
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "farm_id")
+    private Farm farm;
+
+    @Comment("예약자")
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private Member member;
+
+    @Comment("예약 시간")
+    @Column(name = "reservation_time")
+    @OneToOne(fetch = FetchType.LAZY)
+    private FarmSchedule scheduleId;
+
+    @Comment("예약 날짜")
+    @Column(name = "reservation_date")
+    private LocalDate reservationDate;
+
+    @Comment("예약 인원")
+    @Column(name = "reservation_count")
+    private int reservationCount;
+
+    @Comment("예약 상태")
+    @Enumerated(EnumType.STRING)
+    private ReservationStatus status;
+
+    @Comment("요청 사항")
+    @Column(name = "request")
+    private String request;
+
+
+    @Builder
+    public Reservation(Farm farm, Member member, FarmSchedule scheduleId, LocalDate reservationDate, int reservationCount, ReservationStatus status, String request) {
+        this.farm = farm;
+        this.member = member;
+        this.scheduleId = scheduleId;
+        this.reservationDate = reservationDate;
+        this.reservationCount = reservationCount;
+        this.status = status;
+        this.request = request;
+    }
+}

--- a/src/main/java/poomasi/domain/reservation/entity/Reservation.java
+++ b/src/main/java/poomasi/domain/reservation/entity/Reservation.java
@@ -52,7 +52,7 @@ public class Reservation {
 
     @Comment("예약 인원")
     @Column(nullable = false)
-    private int reservationCount;
+    private int memberCount;
 
     @Comment("예약 상태")
     @Enumerated(EnumType.STRING)
@@ -74,12 +74,12 @@ public class Reservation {
 
 
     @Builder
-    public Reservation(Farm farm, Member member, FarmSchedule scheduleId, LocalDate reservationDate, int reservationCount, ReservationStatus status, String request) {
+    public Reservation(Farm farm, Member member, FarmSchedule scheduleId, LocalDate reservationDate, int memberCount, ReservationStatus status, String request) {
         this.farm = farm;
         this.member = member;
         this.scheduleId = scheduleId;
         this.reservationDate = reservationDate;
-        this.reservationCount = reservationCount;
+        this.memberCount = memberCount;
         this.status = status;
         this.request = request;
     }
@@ -90,7 +90,7 @@ public class Reservation {
                 .memberId(member.getId())
                 .scheduleId(scheduleId.getId())
                 .reservationDate(reservationDate)
-                .reservationCount(reservationCount)
+                .memberCount(memberCount)
                 .status(status)
                 .request(request)
                 .build();

--- a/src/main/java/poomasi/domain/reservation/entity/ReservationStatus.java
+++ b/src/main/java/poomasi/domain/reservation/entity/ReservationStatus.java
@@ -1,0 +1,5 @@
+package poomasi.domain.reservation.entity;
+
+public enum ReservationStatus {
+    WAITING, ACCEPTED, REJECTED
+}

--- a/src/main/java/poomasi/domain/reservation/entity/ReservationStatus.java
+++ b/src/main/java/poomasi/domain/reservation/entity/ReservationStatus.java
@@ -1,5 +1,10 @@
 package poomasi.domain.reservation.entity;
 
 public enum ReservationStatus {
-    WAITING, ACCEPTED, REJECTED
+    WAITING, // 대기
+    ACCEPTED, // 수락
+    REJECTED, // 거절
+    CANCELED, // 취소
+    DONE // 완료
+    ;
 }

--- a/src/main/java/poomasi/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/poomasi/domain/reservation/repository/ReservationRepository.java
@@ -1,0 +1,14 @@
+package poomasi.domain.reservation.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import poomasi.domain.reservation.entity.Reservation;
+
+import java.util.List;
+
+@Repository
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+    List<Reservation> findAllByFarmId(Long farmId);
+
+    List<Reservation> findAllByMemberId(Long memberId);
+}

--- a/src/main/java/poomasi/domain/reservation/service/ReservationFarmerService.java
+++ b/src/main/java/poomasi/domain/reservation/service/ReservationFarmerService.java
@@ -1,0 +1,11 @@
+package poomasi.domain.reservation.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationFarmerService {
+
+
+}

--- a/src/main/java/poomasi/domain/reservation/service/ReservationFarmerService.java
+++ b/src/main/java/poomasi/domain/reservation/service/ReservationFarmerService.java
@@ -2,10 +2,20 @@ package poomasi.domain.reservation.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import poomasi.domain.reservation.dto.response.ReservationResponse;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class ReservationFarmerService {
+    private final ReservationService reservationService;
+
+    @Transactional(readOnly = true)
+    public List<ReservationResponse> getReservationsByFarmerId(Long farmerId) {
+        return reservationService.getReservationsByFarmerId(farmerId);
+    }
 
 
 }

--- a/src/main/java/poomasi/domain/reservation/service/ReservationPlatformService.java
+++ b/src/main/java/poomasi/domain/reservation/service/ReservationPlatformService.java
@@ -11,6 +11,8 @@ import poomasi.domain.member.service.MemberService;
 import poomasi.domain.reservation.dto.request.ReservationRequest;
 import poomasi.domain.reservation.dto.response.ReservationResponse;
 import poomasi.domain.reservation.entity.Reservation;
+import poomasi.global.error.BusinessError;
+import poomasi.global.error.BusinessException;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +31,15 @@ public class ReservationPlatformService {
 
         Reservation reservation = reservationService.createReservation(request.toEntity(member, farm, farmSchedule));
 
+
+        return reservation.toResponse();
+    }
+
+    public ReservationResponse getReservation(Long memberId, Long reservationId) {
+        Reservation reservation = reservationService.getReservationById(reservationId);
+        if (!reservation.getMember().getId().equals(memberId) || memberService.isAdmin(memberId)) {
+            throw new BusinessException(BusinessError.RESERVATION_NOT_ACCESSIBLE);
+        }
 
         return reservation.toResponse();
     }

--- a/src/main/java/poomasi/domain/reservation/service/ReservationPlatformService.java
+++ b/src/main/java/poomasi/domain/reservation/service/ReservationPlatformService.java
@@ -2,6 +2,7 @@ package poomasi.domain.reservation.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import poomasi.domain.farm._schedule.entity.FarmSchedule;
 import poomasi.domain.farm._schedule.service.FarmScheduleService;
 import poomasi.domain.farm.entity.Farm;
 import poomasi.domain.farm.service.FarmService;
@@ -9,6 +10,7 @@ import poomasi.domain.member.entity.Member;
 import poomasi.domain.member.service.MemberService;
 import poomasi.domain.reservation.dto.request.ReservationRequest;
 import poomasi.domain.reservation.dto.response.ReservationResponse;
+import poomasi.domain.reservation.entity.Reservation;
 
 @Service
 @RequiredArgsConstructor
@@ -19,16 +21,15 @@ public class ReservationPlatformService {
     private final FarmScheduleService farmScheduleService;
 
     public ReservationResponse createReservation(ReservationRequest request) {
-        // 유효한 멤버를 가져온다.
         Member member = memberService.findMemberById(request.memberId());
+        Farm farm = farmService.getValidFarmByFarmId(request.farmId());
+        FarmSchedule farmSchedule = farmScheduleService.getValidFarmScheduleByFarmIdAndDate(request.farmId(), request.reservationDate());
 
-        // 유효한 농장을 가져온다.
-        Farm farm = farmService.getFarmByFarmId(request.farmId());
+        // TODO: 예약 가능한지 확인하는 로직 추가
 
-        // request가 가능한 날짜인가?
+        Reservation reservation = reservationService.createReservation(request.toEntity(member, farm, farmSchedule));
 
-        // 예약을 생성한다.
 
-        return null;
+        return reservation.toResponse();
     }
 }

--- a/src/main/java/poomasi/domain/reservation/service/ReservationPlatformService.java
+++ b/src/main/java/poomasi/domain/reservation/service/ReservationPlatformService.java
@@ -1,0 +1,34 @@
+package poomasi.domain.reservation.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import poomasi.domain.farm._schedule.service.FarmScheduleService;
+import poomasi.domain.farm.entity.Farm;
+import poomasi.domain.farm.service.FarmService;
+import poomasi.domain.member.entity.Member;
+import poomasi.domain.member.service.MemberService;
+import poomasi.domain.reservation.dto.request.ReservationRequest;
+import poomasi.domain.reservation.dto.response.ReservationResponse;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationPlatformService {
+    private final ReservationService reservationService;
+    private final MemberService memberService;
+    private final FarmService farmService;
+    private final FarmScheduleService farmScheduleService;
+
+    public ReservationResponse createReservation(ReservationRequest request) {
+        // 유효한 멤버를 가져온다.
+        Member member = memberService.findMemberById(request.memberId());
+
+        // 유효한 농장을 가져온다.
+        Farm farm = farmService.getFarmByFarmId(request.farmId());
+
+        // request가 가능한 날짜인가?
+
+        // 예약을 생성한다.
+
+        return null;
+    }
+}

--- a/src/main/java/poomasi/domain/reservation/service/ReservationPlatformService.java
+++ b/src/main/java/poomasi/domain/reservation/service/ReservationPlatformService.java
@@ -40,7 +40,7 @@ public class ReservationPlatformService {
 
     public ReservationResponse getReservation(Long memberId, Long reservationId) {
         Reservation reservation = reservationService.getReservationById(reservationId);
-        if (!reservation.getMember().getId().equals(memberId) || memberService.isAdmin(memberId)) {
+        if (!reservation.getMember().getId().equals(memberId) || !memberService.isAdmin(memberId)) {
             throw new BusinessException(BusinessError.RESERVATION_NOT_ACCESSIBLE);
         }
 
@@ -50,7 +50,7 @@ public class ReservationPlatformService {
     public void cancelReservation(Long memberId, Long reservationId) {
         Reservation reservation = reservationService.getReservationById(reservationId);
 
-        if (!reservation.getMember().getId().equals(memberId) || memberService.isAdmin(memberId)) {
+        if (!reservation.getMember().getId().equals(memberId) || !memberService.isAdmin(memberId)) {
             throw new BusinessException(BusinessError.RESERVATION_NOT_ACCESSIBLE);
         }
 

--- a/src/main/java/poomasi/domain/reservation/service/ReservationService.java
+++ b/src/main/java/poomasi/domain/reservation/service/ReservationService.java
@@ -14,19 +14,19 @@ import java.util.List;
 public class ReservationService {
     private final ReservationRepository reservationRepository;
 
-    private Reservation getReservation(Long id) {
+    public Reservation getReservation(Long id) {
         return reservationRepository.findById(id).orElseThrow(() -> new BusinessException(BusinessError.RESERVATION_NOT_FOUND));
     }
 
-    private List<Reservation> getReservationsByMemberId(Long memberId) {
+    public List<Reservation> getReservationsByMemberId(Long memberId) {
         return reservationRepository.findAllByMemberId(memberId);
     }
 
-    private List<Reservation> getReservationsByFarmId(Long farmId) {
+    public List<Reservation> getReservationsByFarmId(Long farmId) {
         return reservationRepository.findAllByFarmId(farmId);
     }
 
-    private Reservation createReservation(Reservation reservation) {
+    public Reservation createReservation(Reservation reservation) {
         return reservationRepository.save(reservation);
     }
 }

--- a/src/main/java/poomasi/domain/reservation/service/ReservationService.java
+++ b/src/main/java/poomasi/domain/reservation/service/ReservationService.java
@@ -29,4 +29,8 @@ public class ReservationService {
     public Reservation createReservation(Reservation reservation) {
         return reservationRepository.save(reservation);
     }
+
+    public Reservation getReservationById(Long reservationId) {
+        return reservationRepository.findById(reservationId).orElseThrow(() -> new BusinessException(BusinessError.RESERVATION_NOT_FOUND));
+    }
 }

--- a/src/main/java/poomasi/domain/reservation/service/ReservationService.java
+++ b/src/main/java/poomasi/domain/reservation/service/ReservationService.java
@@ -1,0 +1,32 @@
+package poomasi.domain.reservation.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import poomasi.domain.reservation.entity.Reservation;
+import poomasi.domain.reservation.repository.ReservationRepository;
+import poomasi.global.error.BusinessError;
+import poomasi.global.error.BusinessException;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationService {
+    private final ReservationRepository reservationRepository;
+
+    private Reservation getReservation(Long id) {
+        return reservationRepository.findById(id).orElseThrow(() -> new BusinessException(BusinessError.RESERVATION_NOT_FOUND));
+    }
+
+    private List<Reservation> getReservationsByMemberId(Long memberId) {
+        return reservationRepository.findAllByMemberId(memberId);
+    }
+
+    private List<Reservation> getReservationsByFarmId(Long farmId) {
+        return reservationRepository.findAllByFarmId(farmId);
+    }
+
+    private Reservation createReservation(Reservation reservation) {
+        return reservationRepository.save(reservation);
+    }
+}

--- a/src/main/java/poomasi/domain/reservation/service/ReservationService.java
+++ b/src/main/java/poomasi/domain/reservation/service/ReservationService.java
@@ -33,4 +33,9 @@ public class ReservationService {
     public Reservation getReservationById(Long reservationId) {
         return reservationRepository.findById(reservationId).orElseThrow(() -> new BusinessException(BusinessError.RESERVATION_NOT_FOUND));
     }
+
+    public void cancelReservation(Reservation reservation) {
+        reservation.cancel();
+        reservationRepository.save(reservation);
+    }
 }

--- a/src/main/java/poomasi/domain/reservation/service/ReservationService.java
+++ b/src/main/java/poomasi/domain/reservation/service/ReservationService.java
@@ -2,6 +2,7 @@ package poomasi.domain.reservation.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import poomasi.domain.reservation.dto.response.ReservationResponse;
 import poomasi.domain.reservation.entity.Reservation;
 import poomasi.domain.reservation.repository.ReservationRepository;
 import poomasi.global.error.BusinessError;
@@ -37,5 +38,11 @@ public class ReservationService {
     public void cancelReservation(Reservation reservation) {
         reservation.cancel();
         reservationRepository.save(reservation);
+    }
+
+    public List<ReservationResponse> getReservationsByFarmerId(Long farmerId) {
+        return reservationRepository.findAllByFarmId(farmerId).stream()
+                .map(Reservation::toResponse)
+                .toList();
     }
 }

--- a/src/main/java/poomasi/global/error/BusinessError.java
+++ b/src/main/java/poomasi/global/error/BusinessError.java
@@ -39,6 +39,7 @@ public enum BusinessError {
     // Reservation
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "예약을 찾을 수 없습니다."),
     RESERVATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 예약이 존재합니다."),
+    RESERVATION_NOT_ACCESSIBLE(HttpStatus.FORBIDDEN, "접근할 수 없는 예약입니다."),
 
     // ETC
     START_DATE_SHOULD_BE_BEFORE_END_DATE(HttpStatus.BAD_REQUEST, "시작 날짜는 종료 날짜보다 이전이어야 합니다.");

--- a/src/main/java/poomasi/global/error/BusinessError.java
+++ b/src/main/java/poomasi/global/error/BusinessError.java
@@ -32,9 +32,11 @@ public enum BusinessError {
     FARM_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 날짜의 스케줄을 찾을 수 없습니다."),
     FARM_SCHEDULE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 스케줄이 존재합니다."),
 
+    // Reservation
+    RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "예약을 찾을 수 없습니다."),
+
     // ETC
-    START_DATE_SHOULD_BE_BEFORE_END_DATE(HttpStatus.BAD_REQUEST, "시작 날짜는 종료 날짜보다 이전이어야 합니다."),
-    ;
+    START_DATE_SHOULD_BE_BEFORE_END_DATE(HttpStatus.BAD_REQUEST, "시작 날짜는 종료 날짜보다 이전이어야 합니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/poomasi/global/error/BusinessError.java
+++ b/src/main/java/poomasi/global/error/BusinessError.java
@@ -36,10 +36,13 @@ public enum BusinessError {
     FARM_SCHEDULE_ALREADY_RESERVED(HttpStatus.CONFLICT, "해당 날짜에 이미 예약이 존재합니다."),
     FARM_SCHEDULE_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "예약이 불가능한 날짜입니다."),
 
+
     // Reservation
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "예약을 찾을 수 없습니다."),
     RESERVATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 예약이 존재합니다."),
     RESERVATION_NOT_ACCESSIBLE(HttpStatus.FORBIDDEN, "접근할 수 없는 예약입니다."),
+    RESERVATION_ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "이미 취소된 예약입니다."),
+    RESERVATION_CANCELLATION_PERIOD_EXPIRED(HttpStatus.BAD_REQUEST, "예약 취소 기간이 지났습니다."),
 
     // ETC
     START_DATE_SHOULD_BE_BEFORE_END_DATE(HttpStatus.BAD_REQUEST, "시작 날짜는 종료 날짜보다 이전이어야 합니다.");

--- a/src/main/java/poomasi/global/error/BusinessError.java
+++ b/src/main/java/poomasi/global/error/BusinessError.java
@@ -23,17 +23,22 @@ public enum BusinessError {
     INVALID_CREDENTIAL(HttpStatus.UNAUTHORIZED, "잘못된 비밀번호 입니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "리프레시 토큰이 없습니다."),
     REFRESH_TOKEN_NOT_VALID(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 유효하지 않습니다."),
+
     // Farm
     FARM_NOT_FOUND(HttpStatus.NOT_FOUND, "농장을 찾을 수 없습니다."),
     FARM_OWNER_MISMATCH(HttpStatus.FORBIDDEN, "해당 농장의 소유자가 아닙니다."),
     FARM_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 농장이 존재합니다."),
+    FARM_NOT_OPEN(HttpStatus.BAD_REQUEST, "오픈되지 않은 농장입니다."),
 
     // FarmSchedule
     FARM_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 날짜의 스케줄을 찾을 수 없습니다."),
     FARM_SCHEDULE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 스케줄이 존재합니다."),
+    FARM_SCHEDULE_ALREADY_RESERVED(HttpStatus.CONFLICT, "해당 날짜에 이미 예약이 존재합니다."),
+    FARM_SCHEDULE_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "예약이 불가능한 날짜입니다."),
 
     // Reservation
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "예약을 찾을 수 없습니다."),
+    RESERVATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 예약이 존재합니다."),
 
     // ETC
     START_DATE_SHOULD_BE_BEFORE_END_DATE(HttpStatus.BAD_REQUEST, "시작 날짜는 종료 날짜보다 이전이어야 합니다.");


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?

- close #31 
농장 예약 도메인을 생성했습니다.
 예약 관련 작업은 아직 끝나지 않았고, 진행 중이에요. 하지만 개발 속도가 급해서 우선적으로 핵심 기능을 구현했습니다.

## 어떻게 해결했나요?

- 간단하게 농장 예약 및 예약 취소 기능을 구현했습니다.
- 예약 시 예약 가능한 날짜를 조회하고, 해당 날짜에 예약 상태를 업데이트하는 로직을 추가했습니다.
- 예약 취소 기능도 구현했지만, 아직은 간단한 로직만 포함돼 있고, 예약 취소 시점에 대한 제약이나 정책은 추후에 더 상세하게 다뤄야 할 것 같습니다.
- 농장 조회 관련해서도 기본적인 기능을 넣었고, 예약과 연동하여 예약 가능 여부를 처리했습니다.

## 코드 리뷰시 요청 사항

- 코드 전반적으로 봐주시면 좋겠어요. 특히, 예외 처리 부분이나 예약 관련 로직에서 개선할 부분이 있는지 확인 부탁드립니다.

## 더 하고 싶은 말
- 예약 취소 시 취소 규정을 더 세부적으로 설정할 필요가 있습니다. 지금은 임시로 예약 날짜 기준 3일 전까지만 취소 가능하도록 했지만, 추후에 더 정교한 로직이 필요할 것 같습니다.
- 예약과 관련된 세세한 예외 처리나 추가 기능들은 추후 보완할 예정입니다.
- 예약 확인 및 관리 페이지나 API도 필요할 수 있습니다.
