### PR TITLE
Farm Schedule 관리 방식 및 금액제도 수정

### DIFF
--- a/src/main/java/poomasi/domain/farm/_schedule/controller/FarmScheduleFarmerController.java
+++ b/src/main/java/poomasi/domain/farm/_schedule/controller/FarmScheduleFarmerController.java
@@ -21,5 +21,4 @@ public class FarmScheduleFarmerController {
         farmScheduleService.addFarmSchedule(request);
         return ResponseEntity.ok().build();
     }
-
 }

--- a/src/main/java/poomasi/domain/farm/_schedule/dto/FarmScheduleResponse.java
+++ b/src/main/java/poomasi/domain/farm/_schedule/dto/FarmScheduleResponse.java
@@ -5,16 +5,20 @@ import poomasi.domain.farm._schedule.entity.FarmSchedule;
 import poomasi.domain.farm._schedule.entity.ScheduleStatus;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 
 @Builder
 public record FarmScheduleResponse(
         LocalDate date,
+        LocalTime startTime,
+        LocalTime endTime,
         ScheduleStatus status
 ) {
     public static FarmScheduleResponse fromEntity(FarmSchedule farmSchedule) {
         return FarmScheduleResponse.builder()
+                .startTime(farmSchedule.getStartTime())
+                .endTime(farmSchedule.getEndTime())
                 .date(farmSchedule.getDate())
-                .status(farmSchedule.getStatus())
                 .build();
     }
 }

--- a/src/main/java/poomasi/domain/farm/_schedule/dto/FarmScheduleUpdateRequest.java
+++ b/src/main/java/poomasi/domain/farm/_schedule/dto/FarmScheduleUpdateRequest.java
@@ -3,7 +3,6 @@ package poomasi.domain.farm._schedule.dto;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import poomasi.domain.farm._schedule.entity.FarmSchedule;
-import poomasi.domain.farm._schedule.entity.ScheduleStatus;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -21,7 +20,7 @@ public record FarmScheduleUpdateRequest(
 
 
         @NotEmpty(message = "예약 가능한 요일은 필수 값입니다.")
-        List<DayOfWeek> availableDays // 예약 가능한 요일 리스트
+        List<DayOfWeek> availableDays
 ) {
     public FarmSchedule toEntity() {
         return FarmSchedule.builder()

--- a/src/main/java/poomasi/domain/farm/_schedule/dto/FarmScheduleUpdateRequest.java
+++ b/src/main/java/poomasi/domain/farm/_schedule/dto/FarmScheduleUpdateRequest.java
@@ -7,23 +7,26 @@ import poomasi.domain.farm._schedule.entity.ScheduleStatus;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 public record FarmScheduleUpdateRequest(
         Long farmId,
-        @NotNull(message = "시작 날짜는 필수 값입니다.")
-        LocalDate startDate,
-        @NotNull(message = "종료 날짜는 필수 값입니다.")
-        LocalDate endDate,
-        ScheduleStatus status,
+        @NotNull(message = "날짜는 필수 값입니다.")
+        LocalDate date,
+        @NotNull(message = "시작 시간은 필수 값입니다.")
+        LocalTime startTime,
+        @NotNull(message = "종료 시간은 필수 값입니다.")
+        LocalTime endTime,
+
+
         @NotEmpty(message = "예약 가능한 요일은 필수 값입니다.")
         List<DayOfWeek> availableDays // 예약 가능한 요일 리스트
 ) {
-    public FarmSchedule toEntity(LocalDate date) {
+    public FarmSchedule toEntity() {
         return FarmSchedule.builder()
                 .farmId(farmId)
                 .date(date)
-                .status(status)
                 .build();
     }
 }

--- a/src/main/java/poomasi/domain/farm/_schedule/entity/FarmSchedule.java
+++ b/src/main/java/poomasi/domain/farm/_schedule/entity/FarmSchedule.java
@@ -6,6 +6,7 @@ import org.hibernate.annotations.Comment;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Collection;
 
 @Entity
 @Getter
@@ -28,13 +29,11 @@ public class FarmSchedule {
     @Comment("종료 시간")
     private LocalTime endTime;
 
-    @Comment("예약 가능 상태")
-    private Boolean available;
-
-
     @Builder
-    public FarmSchedule(Long farmId, LocalDate date, ScheduleStatus status) {
+    public FarmSchedule(Long farmId, LocalDate date, LocalTime startTime, LocalTime endTime, ScheduleStatus status) {
         this.farmId = farmId;
         this.date = date;
+        this.startTime = startTime;
+        this.endTime = endTime;
     }
 }

--- a/src/main/java/poomasi/domain/farm/_schedule/entity/FarmSchedule.java
+++ b/src/main/java/poomasi/domain/farm/_schedule/entity/FarmSchedule.java
@@ -5,6 +5,7 @@ import lombok.*;
 import org.hibernate.annotations.Comment;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 
 @Entity
 @Getter
@@ -21,20 +22,23 @@ public class FarmSchedule {
     @Comment("예약 가능 날짜")
     private LocalDate date;
 
-    @Setter
-    @Comment("예약 가능 여부")
+    @Comment("시작 시간")
+    private LocalTime startTime;
+
+    @Comment("종료 시간")
+    private LocalTime endTime;
+
+    @Comment("예약 상태")
     @Enumerated(EnumType.STRING)
     private ScheduleStatus status;
+
+    @Comment("예약 가능 상태")
+    private Boolean available;
+
 
     @Builder
     public FarmSchedule(Long farmId, LocalDate date, ScheduleStatus status) {
         this.farmId = farmId;
         this.date = date;
-        this.status = status;
     }
-
-    public void updateStatus(ScheduleStatus status) {
-        this.status = status;
-    }
-
 }

--- a/src/main/java/poomasi/domain/farm/_schedule/entity/FarmSchedule.java
+++ b/src/main/java/poomasi/domain/farm/_schedule/entity/FarmSchedule.java
@@ -28,10 +28,6 @@ public class FarmSchedule {
     @Comment("종료 시간")
     private LocalTime endTime;
 
-    @Comment("예약 상태")
-    @Enumerated(EnumType.STRING)
-    private ScheduleStatus status;
-
     @Comment("예약 가능 상태")
     private Boolean available;
 

--- a/src/main/java/poomasi/domain/farm/_schedule/repository/FarmScheduleRepository.java
+++ b/src/main/java/poomasi/domain/farm/_schedule/repository/FarmScheduleRepository.java
@@ -14,6 +14,6 @@ public interface FarmScheduleRepository extends JpaRepository<FarmSchedule, Long
     @Query("SELECT f FROM FarmSchedule f WHERE f.farmId = :farmId AND f.date BETWEEN :startDate AND :endDate")
     List<FarmSchedule> findByFarmIdAndDateRange(Long farmId, LocalDate startDate, LocalDate endDate);
 
-    Optional<FarmSchedule> findByFarmIdAndDate(Long aLong, LocalDate date);
+    List<FarmSchedule> findByFarmIdAndDate(Long aLong, LocalDate date);
 
 }

--- a/src/main/java/poomasi/domain/farm/_schedule/service/FarmScheduleService.java
+++ b/src/main/java/poomasi/domain/farm/_schedule/service/FarmScheduleService.java
@@ -12,8 +12,7 @@ import poomasi.global.error.BusinessException;
 import java.time.LocalDate;
 import java.util.List;
 
-import static poomasi.global.error.BusinessError.FARM_SCHEDULE_ALREADY_EXISTS;
-import static poomasi.global.error.BusinessError.START_TIME_SHOULD_BE_BEFORE_END_TIME;
+import static poomasi.global.error.BusinessError.*;
 
 @Service
 @RequiredArgsConstructor
@@ -49,5 +48,11 @@ public class FarmScheduleService {
 
     public List<FarmSchedule> getFarmScheduleByFarmIdAndDate(Long farmId, LocalDate date) {
         return farmScheduleRepository.findByFarmIdAndDate(farmId, date);
+    }
+
+    public FarmSchedule getFarmScheduleByScheduleId(Long id) {
+        return farmScheduleRepository.findById(id).orElseThrow(
+                () -> new BusinessException(FARM_SCHEDULE_NOT_FOUND)
+        );
     }
 }

--- a/src/main/java/poomasi/domain/farm/_schedule/service/FarmScheduleService.java
+++ b/src/main/java/poomasi/domain/farm/_schedule/service/FarmScheduleService.java
@@ -22,26 +22,21 @@ public class FarmScheduleService {
     private final FarmScheduleRepository farmScheduleRepository;
 
     public void addFarmSchedule(FarmScheduleUpdateRequest request) {
-        if (request.startDate().isAfter(request.endDate())) {
-            throw new BusinessException(START_DATE_SHOULD_BE_BEFORE_END_DATE);
+        if (request.startTime().isAfter(request.endTime())) {
+            throw new BusinessException(START_TIME_SHOULD_BE_BEFORE_END_TIME);
         }
 
-        List<FarmSchedule> existingSchedules = farmScheduleRepository.findByFarmIdAndDateRange(request.farmId(), request.startDate(), request.endDate());
-
-        Set<LocalDate> existingDates = existingSchedules.stream()
-                .map(FarmSchedule::getDate)
-                .collect(Collectors.toSet());
-
-        for (LocalDate date = request.startDate(); !date.isAfter(request.endDate()); date = date.plusDays(1)) {
-            if (request.availableDays().contains(date.getDayOfWeek())) {
-                if (existingDates.contains(date)) {
-                    throw new BusinessException(FARM_SCHEDULE_ALREADY_EXISTS);
-                }
-
-                FarmSchedule newSchedule = request.toEntity(date);
-                farmScheduleRepository.save(newSchedule);
-            }
+        // 이미 겹치는 예약이 존재하는지 확인
+        List<FarmSchedule> farmSchedules = farmScheduleRepository.findByFarmIdAndDate(request.farmId(), request.date());
+        if (farmSchedules.stream().anyMatch(farmSchedule -> {
+            return (request.startTime().isBefore(farmSchedule.getEndTime()) && request.endTime().isAfter(farmSchedule.getStartTime()));
+        })) {
+            throw new BusinessException(RESERVATION_ALREADY_EXISTS);
         }
+
+        // 등록
+        FarmSchedule farmSchedule = request.toEntity();
+        farmScheduleRepository.save(farmSchedule);
     }
 
     public List<FarmScheduleResponse> getFarmSchedulesByYearAndMonth(FarmScheduleRequest request) {
@@ -53,8 +48,7 @@ public class FarmScheduleService {
                 .toList();
     }
 
-    public FarmSchedule getFarmScheduleByFarmIdAndDate(Long farmId, LocalDate date) {
-        return farmScheduleRepository.findByFarmIdAndDate(farmId, date)
-                .orElseThrow(() -> new BusinessException(FARM_SCHEDULE_NOT_FOUND));
+    public List<FarmSchedule> getFarmScheduleByFarmIdAndDate(Long farmId, LocalDate date) {
+        return farmScheduleRepository.findByFarmIdAndDate(farmId, date);
     }
 }

--- a/src/main/java/poomasi/domain/farm/_schedule/service/FarmScheduleService.java
+++ b/src/main/java/poomasi/domain/farm/_schedule/service/FarmScheduleService.java
@@ -23,11 +23,11 @@ public class FarmScheduleService {
     private final FarmScheduleRepository farmScheduleRepository;
 
     public void addFarmSchedule(FarmScheduleUpdateRequest request) {
-        List<FarmSchedule> existingSchedules = farmScheduleRepository.findByFarmIdAndDateRange(request.farmId(), request.startDate(), request.endDate());
-
         if (request.startDate().isAfter(request.endDate())) {
             throw new BusinessException(START_DATE_SHOULD_BE_BEFORE_END_DATE);
         }
+
+        List<FarmSchedule> existingSchedules = farmScheduleRepository.findByFarmIdAndDateRange(request.farmId(), request.startDate(), request.endDate());
 
         Set<LocalDate> existingDates = existingSchedules.stream()
                 .map(FarmSchedule::getDate)
@@ -67,13 +67,5 @@ public class FarmScheduleService {
         }
 
         return farmSchedule;
-    }
-
-    public void updateFarmScheduleStatus(Long farmScheduleId, ScheduleStatus status) {
-        FarmSchedule farmSchedule = farmScheduleRepository.findById(farmScheduleId)
-                .orElseThrow(() -> new BusinessException(FARM_SCHEDULE_NOT_FOUND));
-
-        farmSchedule.setStatus(status);
-        farmScheduleRepository.save(farmSchedule);
     }
 }

--- a/src/main/java/poomasi/domain/farm/_schedule/service/FarmScheduleService.java
+++ b/src/main/java/poomasi/domain/farm/_schedule/service/FarmScheduleService.java
@@ -6,7 +6,6 @@ import poomasi.domain.farm._schedule.dto.FarmScheduleRequest;
 import poomasi.domain.farm._schedule.dto.FarmScheduleResponse;
 import poomasi.domain.farm._schedule.dto.FarmScheduleUpdateRequest;
 import poomasi.domain.farm._schedule.entity.FarmSchedule;
-import poomasi.domain.farm._schedule.entity.ScheduleStatus;
 import poomasi.domain.farm._schedule.repository.FarmScheduleRepository;
 import poomasi.global.error.BusinessException;
 
@@ -57,15 +56,5 @@ public class FarmScheduleService {
     public FarmSchedule getFarmScheduleByFarmIdAndDate(Long farmId, LocalDate date) {
         return farmScheduleRepository.findByFarmIdAndDate(farmId, date)
                 .orElseThrow(() -> new BusinessException(FARM_SCHEDULE_NOT_FOUND));
-    }
-
-    public FarmSchedule getValidFarmScheduleByFarmIdAndDate(Long farmId, LocalDate date) {
-        FarmSchedule farmSchedule = getFarmScheduleByFarmIdAndDate(farmId, date);
-
-        if (farmSchedule.getStatus() == ScheduleStatus.RESERVED) {
-            throw new BusinessException(FARM_SCHEDULE_ALREADY_RESERVED);
-        }
-
-        return farmSchedule;
     }
 }

--- a/src/main/java/poomasi/domain/farm/_schedule/service/FarmScheduleService.java
+++ b/src/main/java/poomasi/domain/farm/_schedule/service/FarmScheduleService.java
@@ -31,7 +31,7 @@ public class FarmScheduleService {
         if (farmSchedules.stream().anyMatch(farmSchedule -> {
             return (request.startTime().isBefore(farmSchedule.getEndTime()) && request.endTime().isAfter(farmSchedule.getStartTime()));
         })) {
-            throw new BusinessException(RESERVATION_ALREADY_EXISTS);
+            throw new BusinessException(FARM_SCHEDULE_ALREADY_EXISTS);
         }
 
         // 등록

--- a/src/main/java/poomasi/domain/farm/_schedule/service/FarmScheduleService.java
+++ b/src/main/java/poomasi/domain/farm/_schedule/service/FarmScheduleService.java
@@ -11,10 +11,9 @@ import poomasi.global.error.BusinessException;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
-import static poomasi.global.error.BusinessError.*;
+import static poomasi.global.error.BusinessError.FARM_SCHEDULE_ALREADY_EXISTS;
+import static poomasi.global.error.BusinessError.START_TIME_SHOULD_BE_BEFORE_END_TIME;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/poomasi/domain/farm/dto/FarmRegisterRequest.java
+++ b/src/main/java/poomasi/domain/farm/dto/FarmRegisterRequest.java
@@ -11,7 +11,9 @@ public record FarmRegisterRequest(
         Double longitude,
         String phoneNumber,
         String description,
-        Long experiencePrice
+        Long experiencePrice,
+        Integer maxCapacity,
+        Integer maxReservation
 ) {
     public Farm toEntity() {
         return Farm.builder()
@@ -23,6 +25,8 @@ public record FarmRegisterRequest(
                 .longitude(longitude)
                 .description(description)
                 .experiencePrice(experiencePrice)
+                .maxCapacity(maxCapacity)
+                .maxReservation(maxReservation)
                 .build();
     }
 }

--- a/src/main/java/poomasi/domain/farm/entity/Farm.java
+++ b/src/main/java/poomasi/domain/farm/entity/Farm.java
@@ -1,8 +1,10 @@
 package poomasi.domain.farm.entity;
 
 import jakarta.persistence.*;
+
 import java.util.ArrayList;
 import java.util.List;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,6 +16,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 import poomasi.domain.farm.dto.FarmUpdateRequest;
 
 import java.time.LocalDateTime;
+
 import poomasi.domain.review.entity.Review;
 
 @Entity
@@ -100,4 +103,15 @@ public class Farm {
         return this;
     }
 
+    public void updateExpPrice(Long expPrice) {
+        this.experiencePrice = expPrice;
+    }
+
+    public void updateMaxCapacity(Integer maxCapacity) {
+        this.maxCapacity = maxCapacity;
+    }
+
+    public void updateMaxReservation(Integer maxReservation) {
+        this.maxReservation = maxReservation;
+    }
 }

--- a/src/main/java/poomasi/domain/farm/entity/Farm.java
+++ b/src/main/java/poomasi/domain/farm/entity/Farm.java
@@ -70,7 +70,7 @@ public class Farm {
     private LocalDateTime updatedAt = LocalDateTime.now();
 
     @Builder
-    public Farm(String name, Long ownerId, String address, String addressDetail, Double latitude, Double longitude, String description, Long experiencePrice) {
+    public Farm(String name, Long ownerId, String address, String addressDetail, Double latitude, Double longitude, String description, Long experiencePrice, Integer maxCapacity, Integer maxReservation) {
         this.name = name;
         this.ownerId = ownerId;
         this.address = address;
@@ -79,6 +79,8 @@ public class Farm {
         this.longitude = longitude;
         this.description = description;
         this.experiencePrice = experiencePrice;
+        this.maxCapacity = maxCapacity;
+        this.maxReservation = maxReservation;
     }
 
     public Farm updateFarm(FarmUpdateRequest farmUpdateRequest) {

--- a/src/main/java/poomasi/domain/farm/entity/Farm.java
+++ b/src/main/java/poomasi/domain/farm/entity/Farm.java
@@ -1,6 +1,5 @@
 package poomasi.domain.farm.entity;
 
-import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -52,6 +51,12 @@ public class Farm {
 
     @Comment("체험 비용")
     private Long experiencePrice;
+
+    @Comment("팀 최대 인원")
+    private Integer maxCapacity;
+
+    @Comment("동일 시간대 최대 예약 가능 팀 수")
+    private Integer maxReservation;
 
     @Comment("삭제 일시")
     private LocalDateTime deletedAt;

--- a/src/main/java/poomasi/domain/farm/entity/Farm.java
+++ b/src/main/java/poomasi/domain/farm/entity/Farm.java
@@ -92,4 +92,5 @@ public class Farm {
         this.description = farmUpdateRequest.description();
         return this;
     }
+
 }

--- a/src/main/java/poomasi/domain/farm/entity/Farm.java
+++ b/src/main/java/poomasi/domain/farm/entity/Farm.java
@@ -53,6 +53,12 @@ public class Farm {
     @Comment("체험 비용")
     private Long experiencePrice;
 
+    @Comment("팀 최대 인원")
+    private Integer maxCapacity;
+
+    @Comment("동일 시간대 최대 예약 가능 팀 수")
+    private Integer maxReservation;
+
     @Comment("삭제 일시")
     private LocalDateTime deletedAt;
 

--- a/src/main/java/poomasi/domain/farm/service/FarmFarmerService.java
+++ b/src/main/java/poomasi/domain/farm/service/FarmFarmerService.java
@@ -40,6 +40,30 @@ public class FarmFarmerService {
         return farmRepository.findByIdAndDeletedAtIsNull(farmId).orElseThrow(() -> new BusinessException(FARM_NOT_FOUND));
     }
 
+    public void updateFarmExpPrice(Long farmerId, Long farmId, Long expPrice) {
+        Farm farm = this.getFarmByFarmId(farmId);
+        if (!farm.getOwnerId().equals(farmerId)) {
+            throw new BusinessException(FARM_OWNER_MISMATCH);
+        }
+        farm.updateExpPrice(expPrice);
+    }
+
+    public void updateFarmMaxCapacity(Long farmerId, Long farmId, Integer maxCapacity) {
+        Farm farm = this.getFarmByFarmId(farmId);
+        if (!farm.getOwnerId().equals(farmerId)) {
+            throw new BusinessException(FARM_OWNER_MISMATCH);
+        }
+        farm.updateMaxCapacity(maxCapacity);
+    }
+
+    public void updateFarmMaxReservation(Long farmerId, Long farmId, Integer maxReservation) {
+        Farm farm = this.getFarmByFarmId(farmId);
+        if (!farm.getOwnerId().equals(farmerId)) {
+            throw new BusinessException(FARM_OWNER_MISMATCH);
+        }
+        farm.updateMaxReservation(maxReservation);
+    }
+
     public void deleteFarm(Long farmerId, Long farmId) {
         Farm farm = this.getFarmByFarmId(farmId);
         if (!farm.getOwnerId().equals(farmerId)) {

--- a/src/main/java/poomasi/domain/reservation/dto/request/ReservationRequest.java
+++ b/src/main/java/poomasi/domain/reservation/dto/request/ReservationRequest.java
@@ -12,7 +12,7 @@ import java.time.LocalDate;
 public record ReservationRequest(
         Long farmId,
         Long memberId,
-        LocalDate reservationDate,
+        Long scheduleId,
 
         int memberCount,
         String request
@@ -22,7 +22,7 @@ public record ReservationRequest(
                 .member(member)
                 .farm(farm)
                 .scheduleId(farmSchedule)
-                .reservationDate(reservationDate)
+                .reservationDate(farmSchedule.getDate())
                 .memberCount(memberCount)
                 .request(request)
                 .build();

--- a/src/main/java/poomasi/domain/reservation/dto/request/ReservationRequest.java
+++ b/src/main/java/poomasi/domain/reservation/dto/request/ReservationRequest.java
@@ -5,6 +5,7 @@ import poomasi.domain.farm._schedule.entity.FarmSchedule;
 import poomasi.domain.farm.entity.Farm;
 import poomasi.domain.member.entity.Member;
 import poomasi.domain.reservation.entity.Reservation;
+import poomasi.domain.reservation.entity.ReservationStatus;
 
 import java.time.LocalDate;
 
@@ -25,6 +26,7 @@ public record ReservationRequest(
                 .reservationDate(farmSchedule.getDate())
                 .memberCount(memberCount)
                 .request(request)
+                .status(ReservationStatus.ACCEPTED)
                 .build();
     }
 }

--- a/src/main/java/poomasi/domain/reservation/entity/Reservation.java
+++ b/src/main/java/poomasi/domain/reservation/entity/Reservation.java
@@ -101,4 +101,8 @@ public class Reservation {
         this.status = ReservationStatus.CANCELED;
         this.canceledAt = LocalDateTime.now();
     }
+
+    public boolean isNotCancelled() {
+        return !isCanceled();
+    }
 }

--- a/src/main/java/poomasi/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/poomasi/domain/reservation/repository/ReservationRepository.java
@@ -2,6 +2,7 @@ package poomasi.domain.reservation.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import poomasi.domain.farm._schedule.entity.FarmSchedule;
 import poomasi.domain.reservation.entity.Reservation;
 
 import java.util.List;
@@ -11,4 +12,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     List<Reservation> findAllByFarmId(Long farmId);
 
     List<Reservation> findAllByMemberId(Long memberId);
+
+    List<Reservation> findAllByFarmIdAndScheduleId(Long farm_id, FarmSchedule scheduleId);
 }

--- a/src/main/java/poomasi/domain/reservation/service/ReservationPlatformService.java
+++ b/src/main/java/poomasi/domain/reservation/service/ReservationPlatformService.java
@@ -2,8 +2,8 @@ package poomasi.domain.reservation.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import poomasi.domain.farm._schedule.entity.FarmSchedule;
-import poomasi.domain.farm._schedule.entity.ScheduleStatus;
 import poomasi.domain.farm._schedule.service.FarmScheduleService;
 import poomasi.domain.farm.entity.Farm;
 import poomasi.domain.farm.service.FarmService;
@@ -17,6 +17,7 @@ import poomasi.global.error.BusinessException;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ReservationPlatformService {
     private final ReservationService reservationService;
     private final MemberService memberService;
@@ -25,15 +26,25 @@ public class ReservationPlatformService {
 
     private final int RESERVATION_CANCELLATION_PERIOD = 3;
 
+    @Transactional
     public ReservationResponse createReservation(ReservationRequest request) {
         Member member = memberService.findMemberById(request.memberId());
         Farm farm = farmService.getValidFarmByFarmId(request.farmId());
-        FarmSchedule farmSchedule = farmScheduleService.getValidFarmScheduleByFarmIdAndDate(request.farmId(), request.reservationDate());
+        FarmSchedule farmSchedule = farmScheduleService.getFarmScheduleByFarmIdAndDate(farm.getId(), request.reservationDate());
 
-        // TODO: 예약 가능한지 확인하는 로직 추가
+        // 1. 농장에 최대 수용 가능 팀 확인
+        int reservationCount = reservationService.getValidReservationsByFarmIdAndScheduleId(farm.getId(), farmSchedule).size();
+        if (reservationCount >= farm.getMaxReservation()) {
+            throw new BusinessException(BusinessError.RESERVATION_FULL);
+        }
+
+
+        // 2. 농장에서 최대 수용 가능 인원 확인
+        if (request.memberCount() > farm.getMaxCapacity()) {
+            throw new BusinessException(BusinessError.RESERVATION_MEMBER_EXCEED);
+        }
 
         Reservation reservation = reservationService.createReservation(request.toEntity(member, farm, farmSchedule));
-
 
         return reservation.toResponse();
     }
@@ -47,6 +58,7 @@ public class ReservationPlatformService {
         return reservation.toResponse();
     }
 
+    @Transactional
     public void cancelReservation(Long memberId, Long reservationId) {
         Reservation reservation = reservationService.getReservationById(reservationId);
 
@@ -64,6 +76,5 @@ public class ReservationPlatformService {
         }
 
         reservationService.cancelReservation(reservation);
-        farmScheduleService.updateFarmScheduleStatus(reservation.getScheduleId().getId(), ScheduleStatus.PENDING);
     }
 }

--- a/src/main/java/poomasi/domain/reservation/service/ReservationPlatformService.java
+++ b/src/main/java/poomasi/domain/reservation/service/ReservationPlatformService.java
@@ -15,6 +15,8 @@ import poomasi.domain.reservation.entity.Reservation;
 import poomasi.global.error.BusinessError;
 import poomasi.global.error.BusinessException;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -30,7 +32,7 @@ public class ReservationPlatformService {
     public ReservationResponse createReservation(ReservationRequest request) {
         Member member = memberService.findMemberById(request.memberId());
         Farm farm = farmService.getValidFarmByFarmId(request.farmId());
-        FarmSchedule farmSchedule = farmScheduleService.getFarmScheduleByFarmIdAndDate(farm.getId(), request.reservationDate());
+        FarmSchedule farmSchedule = farmScheduleService.getFarmScheduleByScheduleId(request.scheduleId());
 
         // 1. 농장에 최대 수용 가능 팀 확인
         int reservationCount = reservationService.getValidReservationsByFarmIdAndScheduleId(farm.getId(), farmSchedule).size();
@@ -43,7 +45,6 @@ public class ReservationPlatformService {
         if (request.memberCount() > farm.getMaxCapacity()) {
             throw new BusinessException(BusinessError.RESERVATION_MEMBER_EXCEED);
         }
-
         Reservation reservation = reservationService.createReservation(request.toEntity(member, farm, farmSchedule));
 
         return reservation.toResponse();

--- a/src/main/java/poomasi/domain/reservation/service/ReservationService.java
+++ b/src/main/java/poomasi/domain/reservation/service/ReservationService.java
@@ -2,6 +2,7 @@ package poomasi.domain.reservation.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import poomasi.domain.farm._schedule.entity.FarmSchedule;
 import poomasi.domain.reservation.dto.response.ReservationResponse;
 import poomasi.domain.reservation.entity.Reservation;
 import poomasi.domain.reservation.repository.ReservationRepository;
@@ -43,6 +44,12 @@ public class ReservationService {
     public List<ReservationResponse> getReservationsByFarmerId(Long farmerId) {
         return reservationRepository.findAllByFarmId(farmerId).stream()
                 .map(Reservation::toResponse)
+                .toList();
+    }
+
+    public List<Reservation> getValidReservationsByFarmIdAndScheduleId(Long farmId, FarmSchedule farmSchedule) {
+        return reservationRepository.findAllByFarmIdAndScheduleId(farmId, farmSchedule).stream()
+                .filter(Reservation::isNotCancelled)
                 .toList();
     }
 }

--- a/src/main/java/poomasi/global/error/BusinessError.java
+++ b/src/main/java/poomasi/global/error/BusinessError.java
@@ -47,6 +47,8 @@ public enum BusinessError {
     RESERVATION_NOT_ACCESSIBLE(HttpStatus.FORBIDDEN, "접근할 수 없는 예약입니다."),
     RESERVATION_ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "이미 취소된 예약입니다."),
     RESERVATION_CANCELLATION_PERIOD_EXPIRED(HttpStatus.BAD_REQUEST, "예약 취소 기간이 지났습니다."),
+    RESERVATION_FULL(HttpStatus.BAD_REQUEST, "예약이 꽉 찼습니다."),
+    RESERVATION_MEMBER_EXCEED(HttpStatus.BAD_REQUEST, "최대 수용 가능 인원을 초과했습니다."),
 
     // ETC
     START_DATE_SHOULD_BE_BEFORE_END_DATE(HttpStatus.BAD_REQUEST, "시작 날짜는 종료 날짜보다 이전이어야 합니다.");

--- a/src/main/java/poomasi/global/error/BusinessError.java
+++ b/src/main/java/poomasi/global/error/BusinessError.java
@@ -39,6 +39,7 @@ public enum BusinessError {
     FARM_SCHEDULE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 스케줄이 존재합니다."),
     FARM_SCHEDULE_ALREADY_RESERVED(HttpStatus.CONFLICT, "해당 날짜에 이미 예약이 존재합니다."),
     FARM_SCHEDULE_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "예약이 불가능한 날짜입니다."),
+    START_TIME_SHOULD_BE_BEFORE_END_TIME(HttpStatus.BAD_REQUEST, "시작 시간은 종료 시간보다 이전이어야 합니다."),
 
 
     // Reservation


### PR DESCRIPTION
> 아직 작업중인데 검토차 올립니다.

## 해결하려는 문제가 무엇인가요?

- close #62 

## 어떻게 해결했나요?

- 기존에 FarmSchedule에서 예약 하나를 담당하도록 하여, 하루에 딱 한 팀만 예약을 가능하게 했다면,
- 네이버 예약과 같이 한팀당 최대 수용가능 인원을 두고, 동시간대 수용 가능한 팀을 두도록 수정했습니다.
- FarmSchedule은 그저 예약 가능 시간만 담당할 수 있도록 수정했습니다.

## 코드 리뷰시 요청 사항

- 현재 예약한 팀을 매번 reservation에서 쿼리를 날려 조회하는 방향이 좋은지 고민이 됩니다.
- 

## 더 하고 싶은 말

- 더 작업하는대로 계속 업데이트 하겠습니다!!
