### PR TITLE
토큰 재발급, 이미지, 농부로 전환 약간의 수정

### DIFF
--- a/src/main/java/poomasi/domain/auth/token/refreshtoken/service/RefreshTokenService.java
+++ b/src/main/java/poomasi/domain/auth/token/refreshtoken/service/RefreshTokenService.java
@@ -1,7 +1,6 @@
 package poomasi.domain.auth.token.refreshtoken.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/poomasi/domain/auth/token/reissue/controller/ReissueTokenController.java
+++ b/src/main/java/poomasi/domain/auth/token/reissue/controller/ReissueTokenController.java
@@ -10,24 +10,20 @@ import org.springframework.web.bind.annotation.RestController;
 import poomasi.domain.auth.token.reissue.dto.ReissueRequest;
 import poomasi.domain.auth.token.reissue.dto.ReissueResponse;
 import poomasi.domain.auth.token.reissue.service.ReissueTokenService;
-import poomasi.domain.auth.token.util.JwtUtil;
 
 @RestController
 @RequiredArgsConstructor
 public class ReissueTokenController {
 
     private final ReissueTokenService reissueTokenService;
-    private final JwtUtil jwtUtil;
 
     @PostMapping("/api/reissue")
     public ResponseEntity<ReissueResponse> reissue(@RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader,
                                                    @RequestBody ReissueRequest reissueRequest){
 
-        String token = authorizationHeader.replace("Bearer ", "");
+        String accessToken = authorizationHeader.replace("Bearer ", "");
 
-        Long memberId = jwtUtil.getIdFromToken(token);
-
-        return ResponseEntity.ok(reissueTokenService.reissueToken(memberId, reissueRequest));
+        return ResponseEntity.ok(reissueTokenService.reissueToken(accessToken, reissueRequest));
     }
 
 }

--- a/src/main/java/poomasi/domain/auth/token/reissue/controller/ReissueTokenController.java
+++ b/src/main/java/poomasi/domain/auth/token/reissue/controller/ReissueTokenController.java
@@ -1,30 +1,33 @@
 package poomasi.domain.auth.token.reissue.controller;
 
-
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.annotation.Secured;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
-import poomasi.domain.auth.security.userdetail.UserDetailsImpl;
 import poomasi.domain.auth.token.reissue.dto.ReissueRequest;
 import poomasi.domain.auth.token.reissue.dto.ReissueResponse;
 import poomasi.domain.auth.token.reissue.service.ReissueTokenService;
-import poomasi.domain.member.entity.Member;
+import poomasi.domain.auth.token.util.JwtUtil;
 
 @RestController
+@RequiredArgsConstructor
 public class ReissueTokenController {
 
-    @Autowired
-    private ReissueTokenService reissueTokenService;
+    private final ReissueTokenService reissueTokenService;
+    private final JwtUtil jwtUtil;
 
-    @Secured({"ROLE_FARMER", "ROLE_CUSTOMER"})
     @PostMapping("/api/reissue")
-    public ResponseEntity<ReissueResponse> reissue(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestBody ReissueRequest reissueRequest){
-        Member member = userDetails.getMember();
-        return ResponseEntity.ok(reissueTokenService.reissueToken(member.getId(), reissueRequest));
+    public ResponseEntity<ReissueResponse> reissue(@RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader,
+                                                   @RequestBody ReissueRequest reissueRequest){
+
+        String token = authorizationHeader.replace("Bearer ", "");
+
+        Long memberId = jwtUtil.getIdFromToken(token);
+
+        return ResponseEntity.ok(reissueTokenService.reissueToken(memberId, reissueRequest));
     }
 
 }

--- a/src/main/java/poomasi/domain/auth/token/reissue/service/ReissueTokenService.java
+++ b/src/main/java/poomasi/domain/auth/token/reissue/service/ReissueTokenService.java
@@ -18,7 +18,9 @@ public class ReissueTokenService {
     private final RefreshTokenService refreshTokenService;
 
     // 토큰 재발급
-    public ReissueResponse reissueToken(Long memberId, ReissueRequest reissueRequest) {
+    public ReissueResponse reissueToken(String accessToken, ReissueRequest reissueRequest) {
+        Long memberId = jwtUtil.getIdFromToken(accessToken);
+
         String refreshToken = reissueRequest.refreshToken();
         Long requestMemberId = jwtUtil.getIdFromToken(refreshToken);
 

--- a/src/main/java/poomasi/domain/image/controller/ImageController.java
+++ b/src/main/java/poomasi/domain/image/controller/ImageController.java
@@ -22,7 +22,7 @@ public class ImageController {
 
     // 이미지 정보 저장
     @PostMapping
-    @Secured({"ROLE_MEMBER", "ROLE_FARMER", "ROLE_ADMIN"})
+    @Secured({"ROLE_CUSTOMER", "ROLE_FARMER", "ROLE_ADMIN"})
     public ResponseEntity<?> saveImageInfo(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestBody ImageRequest imageRequest) {
         Member member = userDetails.getMember();
         Image savedImage = imageService.saveImage(member.getId(), imageRequest);
@@ -31,7 +31,7 @@ public class ImageController {
 
     // 여러 이미지 정보 저장
     @PostMapping("/multiple")
-    @Secured({"ROLE_MEMBER", "ROLE_FARMER", "ROLE_ADMIN"})
+    @Secured({"ROLE_CUSTOMER", "ROLE_FARMER", "ROLE_ADMIN"})
     public ResponseEntity<List<Image>> saveMultipleImages(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestBody List<ImageRequest> imageRequests) {
         Member member = userDetails.getMember();
         List<Image> savedImages = imageService.saveMultipleImages(member.getId(), imageRequests);
@@ -40,7 +40,7 @@ public class ImageController {
 
     // 특정 이미지 삭제
     @DeleteMapping("/delete/{id}")
-    @Secured({"ROLE_MEMBER", "ROLE_FARMER", "ROLE_ADMIN"})
+    @Secured({"ROLE_CUSTOMER", "ROLE_FARMER", "ROLE_ADMIN"})
     public ResponseEntity<Void> deleteImage(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long id) {
         Member member = userDetails.getMember();
         imageService.deleteImage(member.getId(), id);
@@ -62,7 +62,7 @@ public class ImageController {
 
     // 이미지 정보 수정
     @PutMapping("update/{id}")
-    @Secured({"ROLE_MEMBER", "ROLE_FARMER", "ROLE_ADMIN"})
+    @Secured({"ROLE_CUSTOMER", "ROLE_FARMER", "ROLE_ADMIN"})
     public ResponseEntity<?> updateImageInfo(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                              @PathVariable Long id,
                                              @RequestBody ImageRequest imageRequest) {
@@ -72,7 +72,7 @@ public class ImageController {
     }
 
     @PutMapping("/recover/{id}")
-    @Secured({"ROLE_MEMBER", "ROLE_FARMER", "ROLE_ADMIN"})
+    @Secured({"ROLE_CUSTOMER", "ROLE_FARMER", "ROLE_ADMIN"})
     public ResponseEntity<Void> recoverImage(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long id) {
         Member member = userDetails.getMember();
         imageService.recoverImage(member.getId(), id);

--- a/src/main/java/poomasi/domain/image/repository/ImageRepository.java
+++ b/src/main/java/poomasi/domain/image/repository/ImageRepository.java
@@ -1,12 +1,14 @@
 package poomasi.domain.image.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 import poomasi.domain.image.entity.Image;
 import poomasi.domain.image.entity.ImageType;
 
 import java.util.List;
 import java.util.Optional;
 
+@Repository
 public interface ImageRepository extends JpaRepository<Image, Long> {
     long countByTypeAndReferenceIdAndDeletedAtIsNull(ImageType type, Long referenceId);
     List<Image> findByTypeAndReferenceIdAndDeletedAtIsNull(ImageType type, Long referenceId);

--- a/src/main/java/poomasi/domain/image/service/ImageService.java
+++ b/src/main/java/poomasi/domain/image/service/ImageService.java
@@ -10,6 +10,7 @@ import poomasi.domain.image.repository.ImageRepository;
 import poomasi.domain.image.validation.ImageOwnerValidator;
 import poomasi.domain.image.validation.ImageOwnerValidatorFactory;
 import poomasi.domain.member._profile.entity.MemberProfile;
+import poomasi.domain.member._profile.service.MemberProfileService;
 import poomasi.domain.member.entity.Member;
 import poomasi.domain.member.repository.MemberRepository;
 import poomasi.global.error.BusinessException;

--- a/src/main/java/poomasi/domain/image/service/ImageService.java
+++ b/src/main/java/poomasi/domain/image/service/ImageService.java
@@ -26,6 +26,10 @@ import static poomasi.global.error.BusinessError.*;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ImageService {
+
+    private static final int DEFAULT_IMAGE_LIMIT = 5;
+    private static final int MEMBER_PROFILE_IMAGE_LIMIT = 1;
+
     private final ImageRepository imageRepository;
     private final ImageOwnerValidatorFactory validatorFactory;
     private final MemberRepository memberRepository;
@@ -83,8 +87,10 @@ public class ImageService {
     }
 
     private void validateImageLimit(ImageRequest imageRequest) {
-        int imageLimit = 5;
-        if (imageRequest.type() == ImageType.MEMBER_PROFILE) imageLimit = 1; // 멤버 프로필 이미지는 한 장으로 제한
+        int imageLimit = DEFAULT_IMAGE_LIMIT;
+        if (imageRequest.type() == ImageType.MEMBER_PROFILE) {
+            imageLimit = MEMBER_PROFILE_IMAGE_LIMIT; // 멤버 프로필 이미지는 한 장으로 제한
+        }
 
         if (imageRepository.countByTypeAndReferenceIdAndDeletedAtIsNull(imageRequest.type(), imageRequest.referenceId()) >= imageLimit) {
             throw new BusinessException(IMAGE_LIMIT_EXCEED);

--- a/src/main/java/poomasi/domain/image/service/ImageService.java
+++ b/src/main/java/poomasi/domain/image/service/ImageService.java
@@ -10,7 +10,6 @@ import poomasi.domain.image.repository.ImageRepository;
 import poomasi.domain.image.validation.ImageOwnerValidator;
 import poomasi.domain.image.validation.ImageOwnerValidatorFactory;
 import poomasi.domain.member._profile.entity.MemberProfile;
-import poomasi.domain.member._profile.repository.MemberProfileRepository;
 import poomasi.domain.member.entity.Member;
 import poomasi.domain.member.repository.MemberRepository;
 import poomasi.global.error.BusinessException;
@@ -33,7 +32,7 @@ public class ImageService {
     private final ImageRepository imageRepository;
     private final ImageOwnerValidatorFactory validatorFactory;
     private final MemberRepository memberRepository;
-    private final MemberProfileRepository memberProfileRepository;
+    private final MemberProfileService memberProfileService;
 
 
     @Transactional
@@ -98,10 +97,9 @@ public class ImageService {
     }
 
     private void linkImageToMemberProfile(Long referenceId, Image savedImage) {
-        MemberProfile memberProfile = memberProfileRepository.findById(referenceId)
-                .orElseThrow(() -> new BusinessException(MEMBER_PROFILE_NOT_FOUND));
+        MemberProfile memberProfile = memberProfileService.getMemberProfileById(referenceId);
         memberProfile.setProfileImage(savedImage);
-        memberProfileRepository.save(memberProfile);
+        memberProfileService.saveMemberProfile(memberProfile);
     }
 
     // 여러 이미지 저장

--- a/src/main/java/poomasi/domain/member/_profile/controller/MemberProfileController.java
+++ b/src/main/java/poomasi/domain/member/_profile/controller/MemberProfileController.java
@@ -1,0 +1,14 @@
+package poomasi.domain.member._profile.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import poomasi.domain.member._profile.service.MemberProfileService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/member/profile")
+public class MemberProfileController {
+
+    private final MemberProfileService memberProfileService;
+}

--- a/src/main/java/poomasi/domain/member/_profile/dto/request/MemberProfileRequest.java
+++ b/src/main/java/poomasi/domain/member/_profile/dto/request/MemberProfileRequest.java
@@ -1,0 +1,11 @@
+package poomasi.domain.member._profile.dto.request;
+
+import poomasi.domain.member._profile.entity.MemberProfile;
+
+public record MemberProfileRequest(String name) {
+    public static MemberProfile toEntity(MemberProfileRequest memberProfileRequest){
+        return new MemberProfile(
+                memberProfileRequest.name
+        );
+    }
+}

--- a/src/main/java/poomasi/domain/member/_profile/entity/MemberProfile.java
+++ b/src/main/java/poomasi/domain/member/_profile/entity/MemberProfile.java
@@ -62,4 +62,7 @@ public class MemberProfile {
         this.name = "UNKNOWN"; // name not null 조건 때문에 임시로 넣었습니다. nullable도 true로 넣었는데 안 되네요
     }
 
+    public MemberProfile(String name){
+        this.name = name;
+    }
 }

--- a/src/main/java/poomasi/domain/member/_profile/repository/MemberProfileRepository.java
+++ b/src/main/java/poomasi/domain/member/_profile/repository/MemberProfileRepository.java
@@ -1,7 +1,9 @@
 package poomasi.domain.member._profile.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 import poomasi.domain.member._profile.entity.MemberProfile;
 
+@Repository
 public interface MemberProfileRepository extends JpaRepository<MemberProfile, Long> {
 }

--- a/src/main/java/poomasi/domain/member/_profile/service/MemberProfileService.java
+++ b/src/main/java/poomasi/domain/member/_profile/service/MemberProfileService.java
@@ -1,0 +1,30 @@
+package poomasi.domain.member._profile.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import poomasi.domain.member._profile.dto.request.MemberProfileRequest;
+import poomasi.domain.member._profile.entity.MemberProfile;
+import poomasi.domain.member._profile.repository.MemberProfileRepository;
+import poomasi.global.error.BusinessException;
+
+import static poomasi.global.error.BusinessError.MEMBER_PROFILE_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberProfileService {
+
+    private final MemberProfileRepository memberProfileRepository;
+
+    public MemberProfile getMemberProfileById(Long id){
+        return memberProfileRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(MEMBER_PROFILE_NOT_FOUND));
+    }
+
+    @Transactional
+    public MemberProfile saveMemberProfile(MemberProfileRequest memberProfileRequest){
+        MemberProfile memberProfile = MemberProfileRequest.toEntity(memberProfileRequest);
+        return memberProfileRepository.save(memberProfile);
+    }
+}

--- a/src/main/java/poomasi/domain/member/_profile/service/MemberProfileService.java
+++ b/src/main/java/poomasi/domain/member/_profile/service/MemberProfileService.java
@@ -23,8 +23,7 @@ public class MemberProfileService {
     }
 
     @Transactional
-    public MemberProfile saveMemberProfile(MemberProfileRequest memberProfileRequest){
-        MemberProfile memberProfile = MemberProfileRequest.toEntity(memberProfileRequest);
+    public MemberProfile saveMemberProfile(MemberProfile memberProfile){
         return memberProfileRepository.save(memberProfile);
     }
 }

--- a/src/main/java/poomasi/domain/member/controller/MemberController.java
+++ b/src/main/java/poomasi/domain/member/controller/MemberController.java
@@ -30,11 +30,12 @@ public class MemberController {
                 .signUp(signupRequest));
     }
 
-    @PutMapping("/toFarmer/{memberId}")
-    @Secured("ROLE_ADMIN")
-    public ResponseEntity<Void> convertToFarmer(@PathVariable Long memberId,
+    @PutMapping("/toFarmer")
+    @Secured("ROLE_CUSTOMER")
+    public ResponseEntity<Void> convertToFarmer(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                 @RequestBody FarmerQualificationRequest request) {
-        memberService.convertToFarmer(memberId, request.hasFarmerQualification());
+        Member member = userDetails.getMember();
+        memberService.convertToFarmer(member, request.hasFarmerQualification());
         return ResponseEntity.noContent().build();
     }
 
@@ -60,7 +61,7 @@ public class MemberController {
     }
 
     @GetMapping("/self")
-    @Secured({"ROLE_MEMBER", "ROLE_FARMER", "ROLE_ADMIN"})
+    @Secured({"ROLE_CUSTOMER", "ROLE_FARMER", "ROLE_ADMIN"})
     public ResponseEntity<MemberResponse> getSelfMember(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         Member member = userDetails.getMember();
         MemberResponse memberResponse = memberService.getMemberById(member.getId());
@@ -68,7 +69,7 @@ public class MemberController {
     }
 
     @GetMapping("/summary/{memberId}")
-    @Secured({"ROLE_MEMBER", "ROLE_FARMER", "ROLE_ADMIN"})
+    @Secured({"ROLE_CUSTOMER", "ROLE_FARMER", "ROLE_ADMIN"})
     public ResponseEntity<MemberSummaryResponse> getMemberSummaryById(@PathVariable Long memberId) {
         MemberSummaryResponse memberSummaryResponse = memberService.getMemberSummary(memberId);
         return ResponseEntity.ok(memberSummaryResponse);

--- a/src/main/java/poomasi/domain/member/controller/MemberController.java
+++ b/src/main/java/poomasi/domain/member/controller/MemberController.java
@@ -60,7 +60,7 @@ public class MemberController {
     }
 
     @GetMapping("/self")
-    @Secured({"ROLE_MEMBER", "ROLE_FARMER"})
+    @Secured({"ROLE_MEMBER", "ROLE_FARMER", "ROLE_ADMIN"})
     public ResponseEntity<MemberResponse> getSelfMember(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         Member member = userDetails.getMember();
         MemberResponse memberResponse = memberService.getMemberById(member.getId());

--- a/src/main/java/poomasi/domain/member/service/MemberService.java
+++ b/src/main/java/poomasi/domain/member/service/MemberService.java
@@ -62,9 +62,7 @@ public class MemberService {
     }
 
     @Transactional
-    public void convertToFarmer(Long memberId, Boolean hasFarmerQualification) {
-        Member member = findMemberById(memberId);
-
+    public void convertToFarmer(Member member, Boolean hasFarmerQualification) {
         if (member.isFarmer()) {
             throw new BusinessException(MEMBER_ALREADY_FARMER);
         }

--- a/src/main/java/poomasi/global/config/s3/S3PresignedUrlController.java
+++ b/src/main/java/poomasi/global/config/s3/S3PresignedUrlController.java
@@ -15,14 +15,14 @@ public class S3PresignedUrlController {
     private final AwsProperties awsProperties;
 
     @GetMapping("/presigned-url-get")
-    @Secured({"ROLE_MEMBER", "ROLE_FARMER", "ROLE_ADMIN"})
+    @Secured({"ROLE_CUSTOMER", "ROLE_FARMER", "ROLE_ADMIN"})
     public ResponseEntity<?> presignedUrlGet(@RequestParam String keyname) {
         String presignedGetUrl = s3PresignedUrlService.createPresignedGetUrl(awsProperties.getS3().getBucket(), keyname);
         return ResponseEntity.ok(presignedGetUrl);
     }
 
     @PostMapping("/presigned-url-put")
-    @Secured({"ROLE_MEMBER", "ROLE_FARMER", "ROLE_ADMIN"})
+    @Secured({"ROLE_CUSTOMER", "ROLE_FARMER", "ROLE_ADMIN"})
     public ResponseEntity<?> presignedUrlPut(@RequestBody PresignedUrlPutRequest request) {
         String presignedPutUrl = s3PresignedUrlService.createPresignedPutUrl(awsProperties.getS3().getBucket(), request.keyPrefix(), request.metadata());
         return ResponseEntity.ok(presignedPutUrl);


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?

- close #124 

## 어떻게 해결했나요?

- 토큰 재발급은 필터를 거치지 않기에 따로 헤더에서 액세스 토큰 추출 후 진행하는 방식으로 수정하였습니다.
- 이미지 관련해서 상수 처리, MemberProfileRepository가 아닌 MemberProfileService를 의존하도록 수정하였습니다.
  - 하면서 에러가 생기긴 했는데, 바로 다음 이슈에서 멤버 프로필 관해서 작성할거라 이 때 한번에 수정해서 올리겠습니다 ㅜ
- 농부로 전환은 관리자가 아니라 회원이 바로 할 수 있도록 권한 변경하였습니다.

## 코드 리뷰시 요청 사항

-

## 더 하고 싶은 말

- 할 게 많네요.. 과제가 밀려서
- 지민님 혹시 제 테스트 코드 수정하는 거 많이 급할까요, 주석 처리하고 무시할 수 있으시면 저 다른 거 먼저 좀 하다 테스트 코드 작성할 때 한번에 보고, 좀 신경쓰이시면 오늘 안에 봐보겠습니당
